### PR TITLE
Fix race condition in RDD subconnections

### DIFF
--- a/doc/changes/changes_2.1.1.md
+++ b/doc/changes/changes_2.1.1.md
@@ -7,3 +7,4 @@ Code name:
 ## Features
 
 * #163: Switched to `magic` hadoop committer for intermediate s3 files
+* #200: Dropped JDBC connection cache in `ExasolConnectionManager`


### PR DESCRIPTION
Cache of jdbc connections might lead to situations when two RDD operations involving subconnections are chained together and have a race condition with each other. 