### PR TITLE
Fix wrong data format name in documentation

### DIFF
--- a/doc/user_guide/user_guide.md
+++ b/doc/user_guide/user_guide.md
@@ -49,7 +49,7 @@ For example, when reading from a source `spark.read.format(<FORMAT>)...`.
 
 Depending on the connector variant, use the following formats:
 
-- JDBC &mdash; `"exasol-jdbc"`
+- JDBC &mdash; `"exasol"`
 - S3 &mdash; `"exasol-s3"`
 
 ## Using as Dependency
@@ -225,7 +225,7 @@ Provide the configuration options when creating a dataframe from an Exasol query
 ```scala
 val exasolDF = sparkSession
   .read
-  .format("exasol-jdbc")
+  .format("exasol")
   .option("host", "10.0.0.11")
   .option("port", "8563")
   .option("username", "<USERNAME>")
@@ -304,7 +304,7 @@ Create a dataframe from the query result using JDBC variant:
 ```scala
 val df = sparkSession
   .read
-  .format("exasol-jdbc")
+  .format("exasol")
   .option("host", "10.0.0.11")
   .option("port", "8563")
   .option("username", "<USERNAME>")
@@ -363,7 +363,7 @@ You can also save the Spark dataframe into an Exasol table:
 groupedDF
   .write
   .mode("overwrite")
-  .format("exasol-jdbc")
+  .format("exasol")
   .option("host", "10.0.0.11")
   .option("port", "8563")
   .option("username", "<USERNAME>")

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -457,6 +457,10 @@
                         <!-- CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal') (9.8); -->
                         <!-- https://ossindex.sonatype.org/vulnerability/CVE-2022-26612 -->
                         <exclude>CVE-2022-26612</exclude>
+                        <!-- Transitive dependency io.netty:netty-handler used by software.amazon.awssdk:*.
+                                                Vulnerability still present in latest version 4.1.97.Final.
+                                                We assume that the AWS SDK's usage of netty is not affected. -->
+                        <exclude>CVE-2023-4586</exclude>
                     </excludeVulnerabilityIds>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Code uses `exasol` as format name for jdbc: https://github.com/exasol/spark-connector/blob/main/exasol-jdbc/src/main/scala/com/exasol/spark/DefaultSource.scala#L31

New name `exasol-jdbc` was introduced recently and it is better for backward compatibility to keep the old name rather than change the format name